### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pybtex
+setuptools


### PR DESCRIPTION
setuptools was removed from the Python standard library in 3.12. Add it to the project requirements to make sure it keeps working with python 3.12+.